### PR TITLE
fix(gizmo/controls): Change close keybind to onReleased

### DIFF
--- a/client/gizmo.lua
+++ b/client/gizmo.lua
@@ -235,7 +235,7 @@ lib.addKeybind({
     name = 'gizmoclose',
     description = locale("close_gizmo_description"),
     defaultKey = 'RETURN',
-    onPressed = function(self)
+    onReleased = function(self)
         if not gizmoEnabled then return end
         gizmoEnabled = false
     end,


### PR DESCRIPTION
This will fixes #9. We have this solution in testing for almost two weeks withouth any error or F8 flood.